### PR TITLE
added a search bar for Core Pokemon Section

### DIFF
--- a/src/components/CorePokemon/CorePokemon.css
+++ b/src/components/CorePokemon/CorePokemon.css
@@ -72,6 +72,14 @@
     margin-top: -1em;
   }
 
+  .coreControls { display: flex; align-items: center; justify-content: center; gap: 12px; flex-wrap: wrap; }
+  .coreSearch input {
+    min-width: 220px; padding: 0.6em 0.8em; border-radius: 8px;
+    border: 1px solid #ccc; font-size: 1rem; outline: none;
+  }
+  .coreSearch input:focus { border-color: #3b4cca; box-shadow: 0 0 0 3px rgba(59,76,202,0.15); }
+
+
   .dexNav {
     display: flex;
     justify-content: center;


### PR DESCRIPTION
The Pokémon Search Bar lets users quickly find any Pokémon by typing either its name (full or partial) or its Pokédex number. It supports flexible input:

Enter a name (e.g., Pikachu or just pika) to find the matching Pokémon.

Enter a number (e.g., 25 or #25) to jump straight to that Pokémon in the Pokédex.

When you press Enter, the app updates the displayed Pokémon sprite, name, number, and background to match your search result. This provides a faster alternative to scrolling with the Next/Prev arrows.